### PR TITLE
Fix for role name angstwad

### DIFF
--- a/install_docker.yml
+++ b/install_docker.yml
@@ -9,4 +9,4 @@
   become: yes
   become_user: sudo
   roles:
-    - angstwad.docker.ubuntu
+    - angstwad.docker_ubuntu

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,5 +1,5 @@
 - src: https://github.com/angstwad/docker.ubuntu
-  name: angstwad.docker.ubuntu
+  name: angstwad.docker_ubuntu
   version: master
 - src: https://github.com/wunzeco/ansible-docker
   name: wunzeco.docker


### PR DESCRIPTION
Hi @rilindo thanks for your great article. I found that the angstwad role could not run due to the slight naming difference:
- repo name is angstwad/docker.ubuntu 
- but role name is angstwad.docker_ubuntu
